### PR TITLE
Namespace for RDF

### DIFF
--- a/7-ns.md
+++ b/7-ns.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Name Space
+permalink: /ns
+nav_order: 7
+---
+## PaymentPointer
+
+Use `http://paymentpointers.org/ns#PaymentPointer` as the predicate when linking a WebId to a Payment Pointer. Make sure this triple lives in the profile document to which the WebID dereferences. Example:
+
+```ttl
+@prefix pp: <http://paymentpointers.org/ns#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+<#me> a <foaf:Person> ;
+  pp:PaymentPointer "user@example.com".
+```

--- a/7-ns.md
+++ b/7-ns.md
@@ -6,7 +6,7 @@ nav_order: 7
 ---
 ## PaymentPointer
 
-Use `http://paymentpointers.org/ns#PaymentPointer` as the predicate when linking a WebId to a Payment Pointer. Make sure this triple lives in the profile document to which the WebID dereferences. Example:
+Use `http://paymentpointers.org/ns#PaymentPointer` as the predicate when linking a WebID to a Payment Pointer. Make sure this triple lives in the profile document to which the WebID dereferences. Example:
 
 ```ttl
 @prefix pp: <http://paymentpointers.org/ns#>.

--- a/7-ns.md
+++ b/7-ns.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Name Space
+title: Namespace for RDF
 permalink: /ns
 nav_order: 7
 ---


### PR DESCRIPTION
This adds a namespace URL for use in RDF documents.
The current text is a first version to make sure the URL http://paymentpointers.org/ns#PaymentPointer dereferences to something other than a 404; we can improve and extend it later.
See also https://github.com/solid/webmonetization/issues/9 for more details.

CC @joepie @travis @ianconsolata @rubensworks