### PR TITLE
fix: mobile header elements not hidden properly

### DIFF
--- a/src/overrides/Header.astro
+++ b/src/overrides/Header.astro
@@ -37,7 +37,6 @@ const { locale } = Astro.props;
   }
 
   .selects {
-    display: flex;
     gap: var(--sl-nav-gap);
     align-items: center;
   }


### PR DESCRIPTION
The latest Starlight prefixes its own classes with `sl-` and we need to update our override implementations to match.