### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.13.1",
+    "@astrojs/starlight": "^0.15.0",
     "@interledger/docs-design-system": "^0.2.1",
-    "astro": "^3.6.3",
+    "astro": "^4.0.3",
     "sharp": "^0.33.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.13.1",
-    "@interledger/docs-design-system": "^0.1.3",
+    "@interledger/docs-design-system": "^0.2.1",
     "astro": "^3.6.3",
-    "sharp": "^0.32.6"
+    "sharp": "^0.33.0"
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

This PR bumps dependencies to the latest version.

## Context

Astro v4 was released and the latest version of Starlight has dropped support for Astro v3.