### PR TITLE
chore: bump dependencies to latest version

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,9 +10,8 @@ export default defineConfig({
       description:
         "Payment Pointers are a standardized identifier for payment accounts. In the same way that an email address provides an identifier for a mailbox in the email ecosystem a payment pointer is used by an account holder to share the details of their account with a counter-party.",
       customCss: [
-        "./node_modules/@interledger/docs-design-system/src/styles/green-theme.css",
+        "./node_modules/@interledger/docs-design-system/src/styles/teal-theme.css",
         "./node_modules/@interledger/docs-design-system/src/styles/ilf-docs.css",
-        "./src/styles/paymentpointers.css",
       ],
       components: {
         Header: "./src/components/Header.astro",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.16.0",
-    "@interledger/docs-design-system": "^0.2.1",
-    "astro": "^4.2.4",
+    "@astrojs/starlight": "^0.21.1",
+    "@interledger/docs-design-system": "^0.3.2",
+    "astro": "^4.5.6",
     "sharp": "^0.33.2"
   }
 }

--- a/src/styles/paymentpointers.css
+++ b/src/styles/paymentpointers.css
@@ -1,6 +1,0 @@
-/* Override for sidebar height causing weird positioning */
-@media screen and (min-width: 80rem) {
-  nav.sidebar .sidebar-pane {
-    height: initial;
-  }
-}


### PR DESCRIPTION
This PR bumps dependencies to the latest versions, and hence removes the need for the override stylesheet for the sidebar bug (it has been included in the [DDS library](https://github.com/interledger/docs-design-system))