### PR TITLE
chore: removed iana page's overview section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
       plugins: [starlightLinksValidator()],
       components: {
         Header: "./src/components/Header.astro",
+        PageSidebar: './src/components/PageSidebar.astro'
       },
       expressiveCode: {
         styleOverrides: {

--- a/src/components/PageSidebar.astro
+++ b/src/components/PageSidebar.astro
@@ -1,0 +1,17 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+
+const removeOverview = [
+ 'iana',
+]
+const noOverview = removeOverview.includes(Astro.props.slug);
+const toc = noOverview && Astro.props.toc !== undefined
+	? {
+			...Astro.props.toc,
+			items: Astro.props.toc?.items.slice(1),
+	  } 
+	: Astro.props.toc;
+---
+
+<Default {...Astro.props} {toc}><slot /></Default>

--- a/src/content/docs/iana.md
+++ b/src/content/docs/iana.md
@@ -2,7 +2,7 @@
 title: IANA Considerations
 ---
 
-### Well-Known URI
+## Well-Known URI
 
 This specification registers a new well-known URI.
 


### PR DESCRIPTION
Removing the sidebar Overview item on the PP docs iana page.

Also note: changed the iana page 'Well-Known URI' heading to h2, otherwise h3 headings don't show up at all in the sidebar. Is there any reason it was h3?