### PR TITLE
feat: added basic site tracking using Umami

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,18 @@ export default defineConfig({
       title: "Payment Pointers",
       description:
         "Payment Pointers are a standardized identifier for payment accounts. In the same way that an email address provides an identifier for a mailbox in the email ecosystem a payment pointer is used by an account holder to share the details of their account with a counter-party.",
-      customCss: [
+        head: [
+          {
+            tag: 'script',
+            attrs: {
+              defer: true,
+              'data-website-id': 'cab4fd0a-e2db-4666-a974-5b199f0d6d43',
+              src: 'https://ilf-site-analytics.netlify.app/script.js',
+              'data-domains': 'paymentpointers.org'
+            }
+          }
+        ],
+        customCss: [
         "./node_modules/@interledger/docs-design-system/src/styles/teal-theme.css",
         "./node_modules/@interledger/docs-design-system/src/styles/ilf-docs.css",
       ],


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Added an Umami site tracking script so that we can record page visits for the Payment Pointers docs.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

This gets the basic infrastructure in place and allows us to track page views. There will be more work needed to add granular event tracking based on clicking links.  
